### PR TITLE
PR-14 Adicionar licença

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+MIT License
+
+Copyright (c) 2024 Arthur E. Oliveira
+Copyright (c) 2024 Gabriel A. Magioli
+Copyright (c) 2024 Giovana S. Fontes
+Copyright (c) 2024 Gustavo R. Linhares
+Copyright (c) 2024 João V. Farias
+Copyright (c) 2024 Leticia J. Lopes
+Copyright (c) 2024 Sophia S. Silva
+Copyright (c) 2024 Willian R. Silva
+Copyright (c) 2024 Yan B. Aguiar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Adicionar licença MIT, com três nomes (o do meio) sendo reduzido para menor identificação. Emails não adicionado por prevenção de spam.

Resolves #14.